### PR TITLE
at/ihp202/update-use-cases

### DIFF
--- a/src/ProtectedAppPage.tsx
+++ b/src/ProtectedAppPage.tsx
@@ -1,39 +1,16 @@
-import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 import { AppPage } from "@components/layout/AppPage";
-import { useAppContext } from "@context/AppContext/useAppContext";
-import { useUseCasesByStaff } from "@hooks/useUseCasesByStaff";
 import { LoadingAppUI } from "./pages/login/outlets/LoadingApp/interface";
-import { useSignOut } from "@hooks/useSignOut";
+import { useValidatePortalAccess } from "@hooks/useValidatePortalAccess";
 
 function ProtectedAppPage() {
-  const { selectedClient, user, businessManagers, setUseCasesByRole } =
-    useAppContext();
-  const navigate = useNavigate();
-  const { useCases, loading } = useUseCasesByStaff({
-    userName: user?.id ?? "",
-    businessUnitCode: selectedClient?.name ?? "",
-    businessManagerCode: businessManagers?.publicCode ?? "",
-  });
-  const { signOut } = useSignOut();
-  useEffect(() => {
-    if (!selectedClient) {
-      navigate("/login", { replace: true });
-    }
-  }, [selectedClient, navigate]);
+  const { loading, isAuthorized } = useValidatePortalAccess(true);
 
-  useEffect(() => {
-    if (selectedClient && !loading) {
-      if (!useCases?.listOfUseCasesByRoles?.includes("PortalBoardAccess")) {
-        signOut("/error?code=1008");
-      } else {
-        setUseCasesByRole(useCases.listOfUseCasesByRoles);
-      }
-    }
-  }, [loading, selectedClient, useCases, navigate, setUseCasesByRole, signOut]);
-
-  if (loading) {
+  if (loading || isAuthorized === null) {
     return <LoadingAppUI />;
+  }
+
+  if (isAuthorized === false) {
+    return null;
   }
 
   return <AppPage />;

--- a/src/components/layout/AppPage/index.tsx
+++ b/src/components/layout/AppPage/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Outlet } from "react-router-dom";
 import { Grid, Header, useMediaQuery, Icon } from "@inubekit/inubekit";
 import { MdOutlineChevronRight } from "react-icons/md";
@@ -7,6 +7,8 @@ import { userMenu } from "@config/nav.config";
 import { useAppContext } from "@context/AppContext/useAppContext";
 import { IBusinessUnit } from "@ptypes/employeePortalBusiness.types";
 import { BusinessUnitChange } from "@components/inputs/BusinessUnitChange";
+import { useValidatePortalAccess } from "@hooks/useValidatePortalAccess";
+import { LoadingAppUI } from "@pages/login/outlets/LoadingApp/interface";
 
 import {
   StyledAppPage,
@@ -35,8 +37,11 @@ function AppPage() {
   const [collapse, setCollapse] = useState(false);
   const collapseMenuRef = useRef<HTMLDivElement>(null);
   const businessUnitChangeRef = useRef<HTMLDivElement>(null);
-
   const isTablet = useMediaQuery("(max-width: 944px)");
+
+  const [validateTrigger, setValidateTrigger] = useState(!!selectedClient);
+
+  const { loading } = useValidatePortalAccess(validateTrigger);
 
   const handleLogoClick = (businessUnit: IBusinessUnit) => {
     setSelectedClient({
@@ -46,8 +51,20 @@ function AppPage() {
       logo: businessUnit.urlLogo,
     });
 
+    setValidateTrigger(true);
     setCollapse(false);
   };
+
+  useEffect(() => {
+    if (validateTrigger) {
+      const timeout = setTimeout(() => setValidateTrigger(false), 100);
+      return () => clearTimeout(timeout);
+    }
+  }, [validateTrigger]);
+
+  if (loading || validateTrigger) {
+    return <LoadingAppUI />;
+  }
 
   return (
     <StyledAppPage>

--- a/src/hooks/useValidatePortalAccess.ts
+++ b/src/hooks/useValidatePortalAccess.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAppContext } from "@context/AppContext/useAppContext";
+import { useUseCasesByStaff } from "@hooks/useUseCasesByStaff";
+import { useSignOut } from "@hooks/useSignOut";
+
+export function useValidatePortalAccess(trigger: boolean) {
+  const { selectedClient, user, businessManagers, setUseCasesByRole } =
+    useAppContext();
+  const navigate = useNavigate();
+  const { signOut } = useSignOut();
+
+  const [isAuthorized, setIsAuthorized] = useState<boolean | null>(null);
+
+  const { useCases, loading } = useUseCasesByStaff({
+    userName: user?.id ?? "",
+    businessUnitCode: selectedClient?.name ?? "",
+    businessManagerCode: businessManagers?.publicCode ?? "",
+  });
+
+  useEffect(() => {
+    if (!trigger) return;
+
+    if (!selectedClient) {
+      navigate("/login", { replace: true });
+      return;
+    }
+
+    if (!loading && useCases) {
+      const roles = useCases.listOfUseCasesByRoles ?? [];
+
+      if (!roles.includes("PortalBoardAccess")) {
+        setIsAuthorized(false);
+        signOut("/error?code=1008");
+      } else {
+        setUseCasesByRole(roles);
+        setIsAuthorized(true);
+      }
+    }
+  }, [
+    trigger,
+    selectedClient,
+    loading,
+    useCases,
+    navigate,
+    setUseCasesByRole,
+    signOut,
+  ]);
+
+  return {
+    loading,
+    isAuthorized,
+  };
+}


### PR DESCRIPTION
En el header existe la opción de cambiar de unidad de negocio. En esta parte se debe consumir el mismo servicio y almacenar en el contexto, tal y como se realizó en la tarjeta https://github.com/selsa-inube/team-codex/issues/185

Criterio de aceptación.

No debe haber errores de compilación ni de ejecución.
El estado de load debe visualizarse cuando se está esperando al servicio.
Si el servicio genera un error, debe mostrarse la página de error con un mensaje sobre lo ocurrido y cerrar la sesión.