### PR TITLE
At/ihp207/modal privileges multiple business units

### DIFF
--- a/src/ProtectedAppPage.tsx
+++ b/src/ProtectedAppPage.tsx
@@ -1,6 +1,7 @@
 import { AppPage } from "@components/layout/AppPage";
-import { LoadingAppUI } from "./pages/login/outlets/LoadingApp/interface";
 import { useValidatePortalAccess } from "@hooks/useValidatePortalAccess";
+
+import { LoadingAppUI } from "./pages/login/outlets/LoadingApp/interface";
 
 function ProtectedAppPage() {
   const { loading, isAuthorized } = useValidatePortalAccess(true);

--- a/src/components/layout/AppPage/index.tsx
+++ b/src/components/layout/AppPage/index.tsx
@@ -5,10 +5,13 @@ import { MdOutlineChevronRight } from "react-icons/md";
 
 import { userMenu } from "@config/nav.config";
 import { useAppContext } from "@context/AppContext/useAppContext";
-import { IBusinessUnit } from "@ptypes/employeePortalBusiness.types";
 import { BusinessUnitChange } from "@components/inputs/BusinessUnitChange";
 import { useValidatePortalAccess } from "@hooks/useValidatePortalAccess";
+import { InfoModal } from "@components/modals/InfoModal";
+import { getUseCasesByStaff } from "@services/StaffUser/staffPortalBusiness";
 import { LoadingAppUI } from "@pages/login/outlets/LoadingApp/interface";
+
+import { IBusinessUnit } from "./types";
 
 import {
   StyledAppPage,
@@ -31,8 +34,14 @@ const renderLogo = (imgUrl: string, clientName: string) => {
 };
 
 function AppPage() {
-  const { user, logoUrl, selectedClient, businessUnits, setSelectedClient } =
-    useAppContext();
+  const {
+    user,
+    logoUrl,
+    selectedClient,
+    businessUnits,
+    setSelectedClient,
+    businessManagers,
+  } = useAppContext();
 
   const [collapse, setCollapse] = useState(false);
   const collapseMenuRef = useRef<HTMLDivElement>(null);
@@ -40,19 +49,41 @@ function AppPage() {
   const isTablet = useMediaQuery("(max-width: 944px)");
 
   const [validateTrigger, setValidateTrigger] = useState(!!selectedClient);
-
   const { loading } = useValidatePortalAccess(validateTrigger);
 
-  const handleLogoClick = (businessUnit: IBusinessUnit) => {
-    setSelectedClient({
-      id: businessUnit.businessUnitPublicCode,
-      name: businessUnit.businessUnitPublicCode,
-      sigla: businessUnit.abbreviatedName,
-      logo: businessUnit.urlLogo,
-    });
+  const [localModalVisible, setLocalModalVisible] = useState(false);
+  const [, setClientWithoutPrivileges] = useState<IBusinessUnit | null>(null);
 
-    setValidateTrigger(true);
-    setCollapse(false);
+  const handleLogoClick = async (businessUnit: IBusinessUnit) => {
+    try {
+      const useCases = await getUseCasesByStaff(
+        user?.id ?? "",
+        businessManagers?.publicCode ?? "",
+        businessUnit.businessUnitPublicCode,
+      );
+
+      const roles = useCases.listOfUseCasesByRoles ?? [];
+      const hasAccess = roles.includes("PortalBoardAccess");
+
+      if (hasAccess) {
+        setSelectedClient({
+          id: businessUnit.businessUnitPublicCode,
+          name: businessUnit.businessUnitPublicCode,
+          sigla: businessUnit.abbreviatedName,
+          logo: businessUnit.urlLogo,
+        });
+
+        setValidateTrigger(true);
+        setCollapse(false);
+      } else {
+        setClientWithoutPrivileges(businessUnit);
+        setLocalModalVisible(true);
+      }
+    } catch (error) {
+      console.error("Error al obtener privilegios del portal:", error);
+      setClientWithoutPrivileges(businessUnit);
+      setLocalModalVisible(true);
+    }
   };
 
   useEffect(() => {
@@ -68,6 +99,19 @@ function AppPage() {
 
   return (
     <StyledAppPage>
+      {localModalVisible && (
+        <InfoModal
+          title="Acceso no autorizado"
+          titleDescription="No tienes privilegios en esta unidad de negocio"
+          description="Por favor, selecciona otra."
+          buttonText="Cerrar"
+          onCloseModal={() => {
+            setLocalModalVisible(false);
+            setClientWithoutPrivileges(null);
+          }}
+        />
+      )}
+
       <Grid templateRows="auto 1fr" height="100vh" justifyContent="unset">
         <Header
           logoURL={renderLogo(

--- a/src/components/layout/AppPage/types.ts
+++ b/src/components/layout/AppPage/types.ts
@@ -19,5 +19,13 @@ interface INav {
   title: string;
   sections: Record<string, INavSection>;
 }
+interface IBusinessUnit {
+  abbreviatedName: string;
+  businessUnitPublicCode: string;
+  descriptionUse: string;
+  firstMonthOfFiscalYear: string;
+  languageId: string;
+  urlLogo: string;
+}
 
-export type { INav, ISection };
+export type { INav, ISection, IBusinessUnit };

--- a/src/components/modals/InfoModal/index.tsx
+++ b/src/components/modals/InfoModal/index.tsx
@@ -1,0 +1,78 @@
+import { createPortal } from "react-dom";
+import { MdClear } from "react-icons/md";
+import {
+  Icon,
+  Text,
+  Stack,
+  Divider,
+  Button,
+  Blanket,
+  useMediaQuery,
+} from "@inubekit/inubekit";
+
+import { spacing } from "@design/tokens/spacing";
+
+import { StyledModal, StyledContainerClose } from "./styles";
+
+export interface InfoModalProps {
+  buttonText?: string;
+  description?: string;
+  titleDescription?: string;
+  title?: string;
+  portalId?: string;
+  onCloseModal?: () => void;
+}
+
+export function InfoModal(props: InfoModalProps) {
+  const {
+    buttonText = "Entendido",
+    description = "Descripcion por defecto",
+    titleDescription = "Titulo de la descripcion",
+    title = "Información",
+    portalId = "portal",
+    onCloseModal,
+  } = props;
+
+  const isMobile = useMediaQuery("(max-width: 700px)");
+  const portalNode = document.getElementById(portalId);
+
+  if (!portalNode) {
+    throw new Error(
+      "The portal node is not defined. Ensure the specific node exists in the DOM.",
+    );
+  }
+
+  return createPortal(
+    <Blanket>
+      <StyledModal $smallScreen={isMobile}>
+        <Stack alignItems="center" justifyContent="space-between">
+          <Text type="headline" size="small">
+            {title}
+          </Text>
+          <StyledContainerClose onClick={onCloseModal}>
+            <Stack alignItems="center" gap={spacing.s100}>
+              <Text>Cerrar</Text>
+              <Icon
+                icon={<MdClear />}
+                size="24px"
+                cursorHover
+                appearance="dark"
+              />
+            </Stack>
+          </StyledContainerClose>
+        </Stack>
+        <Divider />
+        <Text>{titleDescription}</Text>
+        <Text size="medium" appearance="gray">
+          {description}
+        </Text>
+        <Stack justifyContent="end">
+          <Button onClick={onCloseModal} fullwidth={isMobile} cursorHover>
+            {buttonText}
+          </Button>
+        </Stack>
+      </StyledModal>
+    </Blanket>,
+    portalNode,
+  );
+}

--- a/src/components/modals/InfoModal/stories/InfoModal.stories.tsx
+++ b/src/components/modals/InfoModal/stories/InfoModal.stories.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { StoryFn, Meta } from "@storybook/react";
+import { Button } from "@inubekit/inubekit";
+
+import { InfoModal, InfoModalProps } from "..";
+import { props } from "./props";
+
+const story: Meta<typeof InfoModal> = {
+  component: InfoModal,
+  title: "components/modals/InfoModal",
+  argTypes: props,
+};
+
+const DefaultTemplate: StoryFn<InfoModalProps> = (args) => {
+  const [showModal, setShowModal] = useState(false);
+
+  const handleShowModal = () => {
+    setShowModal(!showModal);
+  };
+
+  return (
+    <>
+      <Button onClick={handleShowModal}>Open Modal</Button>
+      {showModal && <InfoModal {...args} onCloseModal={handleShowModal} />}
+    </>
+  );
+};
+
+export const Default = DefaultTemplate.bind({});
+Default.args = {
+  title: "Información",
+  titleDescription: "¿Por qué está inhabilitado?",
+  description:
+    "Solo es posible renovar los contratos a término fijo, en este caso no se encontró ningún contrato que cumpla con los requisitos.",
+};
+
+export default story;

--- a/src/components/modals/InfoModal/stories/props.ts
+++ b/src/components/modals/InfoModal/stories/props.ts
@@ -1,0 +1,37 @@
+import { ArgTypes } from "@storybook/react";
+
+import { InfoModalProps } from "..";
+
+const props: Partial<ArgTypes<InfoModalProps>> = {
+  buttonText: {
+    control: "text",
+    description: "Text for the primary submit button",
+    defaultValue: "Entendido",
+  },
+  description: {
+    control: "text",
+    description: "Content displayed as the modal's main description",
+    defaultValue: "Descripcion por defecto",
+  },
+  titleDescription: {
+    control: "text",
+    description: "Small heading for the description section",
+    defaultValue: "Titulo de la descripcion",
+  },
+  title: {
+    control: "text",
+    description: "Title of the modal",
+    defaultValue: "Información",
+  },
+  portalId: {
+    control: "text",
+    description: "ID of the portal node for rendering the modal",
+    defaultValue: "portal",
+  },
+  onCloseModal: {
+    action: "closed",
+    description: "Function triggered when the modal is closed",
+  },
+};
+
+export { props };

--- a/src/components/modals/InfoModal/styles.ts
+++ b/src/components/modals/InfoModal/styles.ts
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+import { inube } from "@inubekit/inubekit";
+
+import { spacing } from "@design/tokens/spacing";
+
+interface IStyledModal {
+  $smallScreen: boolean;
+  theme?: typeof inube;
+}
+
+const StyledModal = styled.div<IStyledModal>`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background-color: ${({ theme }) =>
+    theme?.palette?.neutral?.N0 || inube.palette.neutral.N0};
+  height: "inherit";
+  width: ${({ $smallScreen }) => ($smallScreen ? "303px" : "402px")};
+  padding: ${({ $smallScreen }) =>
+    $smallScreen ? spacing.s200 : spacing.s300};
+  gap: ${spacing.s150};
+  border-radius: ${spacing.s100};
+`;
+
+const StyledContainerClose = styled.div`
+  cursor: pointer;
+`;
+
+export { StyledModal, StyledContainerClose };

--- a/src/hooks/useUseCasesByStaff.ts
+++ b/src/hooks/useUseCasesByStaff.ts
@@ -26,6 +26,7 @@ export const useUseCasesByStaff = ({
       if (!userName || !businessManagerCode || !businessUnitCode) {
         setHasError(400);
         setUseCases({ listOfUseCasesByRoles: [] });
+        setLoading(false);
         return;
       }
 

--- a/src/pages/login/outlets/Clients/index.tsx
+++ b/src/pages/login/outlets/Clients/index.tsx
@@ -2,11 +2,13 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useAppContext } from "@context/AppContext/useAppContext";
-import { IClient } from "@context/AppContext/types";
 import { IBusinessUnit } from "@ptypes/employeePortalBusiness.types";
+import { InfoModal } from "@components/modals/InfoModal";
+import { useUseCasesByStaff } from "@hooks/useUseCasesByStaff";
 
 import { ClientsUI } from "./interface";
 import { IClientLocal } from "./types";
+import { IClient } from "./types";
 
 export interface ClientsProps {
   businessUnits?: IBusinessUnit[];
@@ -69,27 +71,62 @@ const ClientsWithContext = () => {
     value: true,
   });
 
+  const [selectedClient, setSelectedClient] = useState<IClient | null>(null);
+  const [showModal, setShowModal] = useState(false);
+
+  const { useCases, loading } = useUseCasesByStaff({
+    userName: context.user?.id ?? "",
+    businessUnitCode: selectedClient?.name ?? "",
+    businessManagerCode: context.businessManagers?.publicCode ?? "",
+  });
+
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setClientLocal({ ref: event.target, value: false });
-    const selectedClient = clients.find(
-      (client) => client.name === event.target.value,
-    );
-    if (selectedClient && context.handleClientChange) {
-      context.handleClientChange(selectedClient);
+    const client = clients.find((c) => c.name === event.target.value);
+
+    if (client && context.handleClientChange) {
+      context.handleClientChange(client);
+      setSelectedClient(client);
     }
   };
 
   const handleSubmit = () => {
-    navigate("/login/loading-app");
+    if (!selectedClient || loading) return;
+
+    const roles = useCases?.listOfUseCasesByRoles ?? [];
+    const hasAccess = roles.includes("PortalBoardAccess");
+
+    if (hasAccess) {
+      navigate("/login/loading-app");
+    } else {
+      setShowModal(true);
+    }
+  };
+
+  const handleCloseModal = () => {
+    setShowModal(false);
+    setSelectedClient(null);
   };
 
   return (
-    <ClientsUI
-      clients={clients}
-      client={clientLocal}
-      handleClientChange={handleChange}
-      handleSubmit={handleSubmit}
-    />
+    <>
+      <ClientsUI
+        clients={clients}
+        client={clientLocal}
+        handleClientChange={handleChange}
+        handleSubmit={handleSubmit}
+      />
+
+      {showModal && (
+        <InfoModal
+          title="Acceso no autorizado"
+          titleDescription="No tienes privilegios en esta unidad de negocio"
+          description="Por favor selecciona otra unidad "
+          buttonText="Cerrar"
+          onCloseModal={handleCloseModal}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/pages/login/outlets/Clients/index.tsx
+++ b/src/pages/login/outlets/Clients/index.tsx
@@ -6,9 +6,8 @@ import { IBusinessUnit } from "@ptypes/employeePortalBusiness.types";
 import { InfoModal } from "@components/modals/InfoModal";
 import { useUseCasesByStaff } from "@hooks/useUseCasesByStaff";
 
+import { IClientLocal, IClient } from "./types";
 import { ClientsUI } from "./interface";
-import { IClientLocal } from "./types";
-import { IClient } from "./types";
 
 export interface ClientsProps {
   businessUnits?: IBusinessUnit[];

--- a/src/pages/login/outlets/Clients/types.ts
+++ b/src/pages/login/outlets/Clients/types.ts
@@ -7,5 +7,11 @@ interface IClientLocal {
   ref: HTMLInputElement | null;
   value: boolean;
 }
+interface IClient {
+  id: string;
+  name: string;
+  sigla: string;
+  logo: string;
+}
 
-export type { IClientState, IClientLocal };
+export type { IClientState, IClientLocal, IClient };

--- a/src/services/StaffUser/staffPortalBusiness/index.tsx
+++ b/src/services/StaffUser/staffPortalBusiness/index.tsx
@@ -34,12 +34,18 @@ const getUseCasesByStaff = async (
 
     clearTimeout(timeoutId);
 
-    const data = await res.json();
+    const text = await res.text();
 
     if (!res.ok) {
+      console.warn("Respuesta no OK:", res.status);
       return { listOfUseCasesByRoles: [] };
     }
 
+    if (!text) {
+      return { listOfUseCasesByRoles: [] };
+    }
+
+    const data = JSON.parse(text);
     return mapUseCasesApiToEntity(data);
   } catch (error) {
     console.error("❌ Error al obtener casos de uso:", error);


### PR DESCRIPTION
Caso 1: con múltiples unidades de negocio.
Al hacer clic en una unidad de negocio que no tenga privilegios, debe mostrarse una ventana modal con el mensaje «No tienes privilegios en esta unidad de negocio, por favor, selecciona otra», y al cerrar dicha ventana modal, debe permitir seleccionar otra unidad de negocio.

Caso 2: con una sola unidad de negocio.
Si el funcionario solo tiene una unidad de negocio, pero no tiene privilegios, debe redirigirse a la página de error (como se encuentra actualmente).

Caso 3: cambiar una unidad de negocio desde el encabezado.
Si se selecciona una unidad de negocio que no tiene privilegios, debe mostrarse una ventana modal con el siguiente mensaje: «No tienes privilegios en esta unidad de negocio, por favor, selecciona otra». Además, debe dejarse seleccionada la unidad de negocio que se encontraba anteriormente.